### PR TITLE
Allows Lambda to post logs to CloudWatch

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,7 @@ data "aws_iam_policy_document" "main" {
     effect = "Allow"
 
     actions = [
+      "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:PutLogEvents",
     ]


### PR DESCRIPTION
When viewing Trusted Advisor, we get this error

```
Missing permissions

Your function doesn't have permission to write to Amazon CloudWatch Logs. To view logs, add the AWSLambdaBasicExecutionRole managed policy to its execution role. Open the IAM console
```

Looking at this doc https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function they provide an IAM Policy that mirrors AWS's built-in policy `AWSLambdaBasicExecutionRole`. This copies that.